### PR TITLE
Implemented configuration options

### DIFF
--- a/HealthChecks.Uptime/Constants.cs
+++ b/HealthChecks.Uptime/Constants.cs
@@ -12,5 +12,6 @@ internal sealed class Constants
         public const string Data_Uptime = "Uptime";
         public const string Data_StartupTime = "Startup Time";
         public const string Data_HealthyDescription = "Application has been running without issues.";
+        public const string Data_DegradedDescription = "Application is experiencing degraded service.";
     }
 }

--- a/HealthChecks.Uptime/Extensions/ServiceCollectionExtension.cs
+++ b/HealthChecks.Uptime/Extensions/ServiceCollectionExtension.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using HealthChecks.Uptime.Options;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace HealthChecks.Uptime;
 
@@ -11,7 +12,24 @@ public static class ServiceCollectionExtension
     /// <returns>The <see cref="IHealthChecksBuilder"/> with the Uptime health check added.</returns>
     public static IHealthChecksBuilder AddUptimeHealthCheck(this IHealthChecksBuilder builder)
     {
-        builder.Services.AddSingleton(implementationInstance: new StartupTimeHealthCheck(DateTime.Now));
+        builder.Services.AddSingleton(implementationInstance: new StartupTimeHealthCheck(DateTime.Now, options: null));
+        builder.AddCheck<StartupTimeHealthCheck>(name: Constants.Configuration.DefaultCheckName);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds the Uptime health check to the <see cref="IHealthChecksBuilder"/> with the specified options.
+    /// </summary>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/> to add the health check to.</param>
+    /// <param name="options">The options for the Uptime health check.</param>
+    /// <returns>The <see cref="IHealthChecksBuilder"/> with the Uptime health check added.</returns>
+    public static IHealthChecksBuilder AddUptimeHealthCheck(this IHealthChecksBuilder builder, Action<UptimeHealthCheckOptions>? options)
+    {
+        UptimeHealthCheckOptions healthCheckOptions = new();
+        options?.Invoke(healthCheckOptions);
+
+        builder.Services.AddSingleton(implementationInstance: new StartupTimeHealthCheck(DateTime.Now, options: healthCheckOptions));
         builder.AddCheck<StartupTimeHealthCheck>(name: Constants.Configuration.DefaultCheckName);
 
         return builder;

--- a/HealthChecks.Uptime/HealthCheck/StartupTimeHealthCheck.cs
+++ b/HealthChecks.Uptime/HealthCheck/StartupTimeHealthCheck.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+﻿using HealthChecks.Uptime.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace HealthChecks.Uptime;
 
@@ -6,9 +7,10 @@ namespace HealthChecks.Uptime;
 /// Initializes a new instance of the <see cref="StartupTimeHealthCheck"/> class.
 /// </summary>
 /// <param name="startupTime">The startup time of the application.</param>
-public sealed class StartupTimeHealthCheck(DateTime startupTime) : IHealthCheck
+public sealed class StartupTimeHealthCheck(DateTime startupTime, UptimeHealthCheckOptions? options) : IHealthCheck
 {
     private readonly DateTime _startupTime = startupTime;
+    private readonly UptimeHealthCheckOptions _options = options ?? new();
 
     /// <summary>
     /// Checks the health of the application's startup time.
@@ -21,10 +23,51 @@ public sealed class StartupTimeHealthCheck(DateTime startupTime) : IHealthCheck
         var uptime = DateTime.Now - _startupTime;
         var data = new Dictionary<string, object>
         {
+            // Formats the startup time as a string using the "o" format specifier (ISO 8601 format)
             { Constants.Language.Data_StartupTime, _startupTime.ToString(format: "o") },
+
+            // Include the uptime as a string
             { Constants.Language.Data_Uptime, uptime.ToString() }
         };
 
-        return Task.FromResult(HealthCheckResult.Healthy(description: Constants.Language.Data_HealthyDescription, data));
+        // Shortcut for when the degraded threshold is not set or is less than 0
+        if (
+            _options.DegradedThresholdInSeconds is null ||
+            _options.DegradedThresholdInSeconds.HasValue && _options.DegradedThresholdInSeconds.Value < 0
+        )
+        {
+            // Create a new HealthCheckResult object with the specified parameters
+            var shortResult = new HealthCheckResult(
+                status: HealthStatus.Healthy,
+                description: Constants.Language.Data_HealthyDescription,
+                data: data
+            );
+
+            return Task.FromResult(shortResult);
+        }
+
+        // Normal operation
+        HealthStatus status;
+        string description;
+
+        if (uptime.TotalSeconds < _options.DegradedThresholdInSeconds)
+        {
+            status = HealthStatus.Degraded;
+            description = Constants.Language.Data_DegradedDescription;
+        }
+        else
+        {
+            status = HealthStatus.Healthy;
+            description = Constants.Language.Data_HealthyDescription;
+        }
+
+        // Create a new HealthCheckResult object with the specified parameters
+        var result = new HealthCheckResult(
+            status: status,
+            description: description,
+            data: data
+        );
+
+        return Task.FromResult(result);
     }
 }

--- a/HealthChecks.Uptime/HealthChecks.Uptime.csproj
+++ b/HealthChecks.Uptime/HealthChecks.Uptime.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>Uptime HealthCheck</Title>
-    <Version>2.0.4</Version>
+    <Version>2.0.5</Version>
     <Authors>Stu Frankish</Authors>
     <Company>Stu Frankish</Company>
     <Description>Application uptime Healthcheck extension.</Description>

--- a/HealthChecks.Uptime/Options/UptimeHealthCheckOptions.cs
+++ b/HealthChecks.Uptime/Options/UptimeHealthCheckOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace HealthChecks.Uptime.Options;
+
+public sealed class UptimeHealthCheckOptions
+{
+    public int? DegradedThresholdInSeconds { get; set; }
+}


### PR DESCRIPTION
# Summary
This change tidies up some structure and adds the ability to set a threshold for the healthcheck status.
Example implementation for the new options;
```c#
// Add Healthchecks
builder.Services.AddHealthChecks()
    .AddUptimeHealthCheck((options) => {
        options.DegradedThresholdInSeconds = 60;
    })
```
The above will configure the health check to return a "degraded" status until the uptime reaches 60 seconds or greater, after which it will return a "healthy" status.

# Testing
The existing unit testing as been refactored and a new test to include the optional configuration has been added.
All tests passing.

![image](https://github.com/StuFrankish/HealthChecks/assets/5624629/202fc7b6-1268-4b41-b39d-bad11aa63fd5)
